### PR TITLE
fix: upgraded @octokit/rest version to avoid printing deprecation warning.

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -1,6 +1,6 @@
 // This helper goes and fetches Good First Issues
 // This module expects a search query which is just a standard GitHub search query. These queries should not include sort or order, since those are defined in the function.
-const Octokit = require('@octokit/rest')
+const { Octokit } = require('@octokit/rest')
 
 /// GitHub search parameters for the Node.js org
 const SORT = 'updated'
@@ -15,7 +15,7 @@ const PAGE = 1 // page_number is 1-based index
 const MAX_PAGE_ALLOWED = 34
 
 async function search (q, auth) {
-  const octokit = auth ? Octokit({ auth }) : Octokit()
+  const octokit = auth ? new Octokit({ auth }) : new Octokit()
 
   const { data } = await octokit.search.issuesAndPullRequests(getSearchParams({ q }))
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "email": "hello@bnb.im"
   },
   "dependencies": {
-    "@octokit/rest": "^16.0.1"
+    "@octokit/rest": "^18.0.6"
   },
   "devDependencies": {
     "jest": "^23.6.0",

--- a/tests/search.spec.js
+++ b/tests/search.spec.js
@@ -6,13 +6,16 @@ beforeEach(() => {
   jest.restoreAllMocks()
   jest.resetAllMocks()
   issuesAndPullRequests = jest.fn()
-  jest.doMock('@octokit/rest', () => () => {
-    return {
-      search: {
-        issuesAndPullRequests
+  jest.doMock("@octokit/rest", () => ({
+    // cannot use arrow function here because we can't call new on arrow function
+    Octokit: function () {
+      return {
+        search: {
+          issuesAndPullRequests
+        }
       }
     }
-  })
+  }))
   search = require('../lib/search')
 })
 


### PR DESCRIPTION
See screenshot below 
![octo](https://user-images.githubusercontent.com/18002820/94464534-e148f100-01be-11eb-8e3b-459ceaa29789.png)
